### PR TITLE
Load bootstrap and other assets from CDN

### DIFF
--- a/testprovider/fixtures.json
+++ b/testprovider/fixtures.json
@@ -1,1 +1,107 @@
-[{"model": "oidc_provider.responsetype", "pk": 1, "fields": {"value": "code", "description": "code (Authorization Code Flow)"}}, {"model": "oidc_provider.responsetype", "pk": 2, "fields": {"value": "id_token", "description": "id_token (Implicit Flow)"}}, {"model": "oidc_provider.responsetype", "pk": 3, "fields": {"value": "id_token token", "description": "id_token token (Implicit Flow)"}}, {"model": "oidc_provider.responsetype", "pk": 4, "fields": {"value": "code token", "description": "code token (Hybrid Flow)"}}, {"model": "oidc_provider.responsetype", "pk": 5, "fields": {"value": "code id_token", "description": "code id_token (Hybrid Flow)"}}, {"model": "oidc_provider.responsetype", "pk": 6, "fields": {"value": "code id_token token", "description": "code id_token token (Hybrid Flow)"}}, {"model": "oidc_provider.client", "pk": 1, "fields": {"name": "testrpHS256", "owner": null, "client_type": "confidential", "client_id": "1", "client_secret": "bd01adf93cfb", "jwt_alg": "HS256", "date_created": "2017-11-10", "website_url": "", "terms_url": "", "contact_email": "", "logo": "", "reuse_consent": true, "require_consent": true, "_redirect_uris": "http://testrp:8081/oidc/callback/", "_post_logout_redirect_uris": "", "_scope": "", "response_types": [1]}}, {"model": "oidc_provider.client", "pk": 2, "fields": {"name": "testrpRS256", "owner": null, "client_type": "confidential", "client_id": "2", "client_secret": "a6b4dad2f215", "jwt_alg": "RS256", "date_created": "2017-11-10", "website_url": "", "terms_url": "", "contact_email": "", "logo": "", "reuse_consent": true, "require_consent": true, "_redirect_uris": "http://testrp:8081/oidc/callback/", "_post_logout_redirect_uris": "", "_scope": "", "response_types": [1]}}, {"model": "oidc_provider.rsakey", "pk": 3, "fields": {"key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDAAgiIdiJG7GSMKTRbnGjWpHp1ulJ43/iQjDywWh5MP3in2PK8\nPVI6ItxIFLV81nWZMymA7hjfP7adOlxKY6rI+fExn8cTimI3W/oX6mHrPXm52uj/\nwe839pxxkeD7cmWgaif9Sujuy5AHUuUM1BTlO55POHkmhWyYMKC2P29qgQIDAQAB\nAoGAUHdJri6b1M8yoA6Qk6frw7AwZfAMqf1qxOEQefN6aQfcf7MKntqwAA8l88tB\n96xEokxvo0mlAMJJvIB9tusn4dIHKpmQGacQWVd/KONxPkvyuGgQXX5KCusZTbg7\ni6YQM52RGbExVFWLdGYJRBvzyfRkWX0b4LiderPZUiD6J/UCQQDZIgnLqYyGw3Ro\nnNboWYyOtLhKMF59f/0aSMXLlWdsnFG8kVm/7tw6jcDBalELci/+ExL2JACGwDea\n8DpvWiEDAkEA4mCovWmMDiS8tQCeY5NDic1wMp51+Ya8RX47bvb5F+X7SSE9L87y\n6eU9zVBSY8F+9npkvrxoU9PlKbS3Lzz1KwJAZ5/8BsuS+lnbe3Wmhtr93rlW3mk5\nHzHu7BVg+GkEI+xygcjoiVYImpU+MdB4fzrutpYJzZie+7BOmU4exTfBWwJBAKj+\nN3mO/Xrhee41VAhJuzV4I7XmDXQFXS8TmRKxVCq/COQC6EZ0W2q4M3a964OEw18E\n54hr5gYOPRjxS378JpkCQDjKw2Vyw0S0M8O2hOGuNsUtlGApYKt2iA41jGUf7bvO\nWz/tQuEIXQMd4e9zxNxOzPJOtjR1gyPZyi/FvsgDJDU=\n-----END RSA PRIVATE KEY-----"}}]
+[
+  {
+    "model": "oidc_provider.responsetype",
+    "pk": 1,
+    "fields": {
+      "value": "code",
+      "description": "code (Authorization Code Flow)"
+    }
+  },
+  {
+    "model": "oidc_provider.responsetype",
+    "pk": 2,
+    "fields": {
+      "value": "id_token",
+      "description": "id_token (Implicit Flow)"
+    }
+  },
+  {
+    "model": "oidc_provider.responsetype",
+    "pk": 3,
+    "fields": {
+      "value": "id_token token",
+      "description": "id_token token (Implicit Flow)"
+    }
+  },
+  {
+    "model": "oidc_provider.responsetype",
+    "pk": 4,
+    "fields": {
+      "value": "code token",
+      "description": "code token (Hybrid Flow)"
+    }
+  },
+  {
+    "model": "oidc_provider.responsetype",
+    "pk": 5,
+    "fields": {
+      "value": "code id_token",
+      "description": "code id_token (Hybrid Flow)"
+    }
+  },
+  {
+    "model": "oidc_provider.responsetype",
+    "pk": 6,
+    "fields": {
+      "value": "code id_token token",
+      "description": "code id_token token (Hybrid Flow)"
+    }
+  },
+  {
+    "model": "oidc_provider.client",
+    "pk": 1,
+    "fields": {
+      "name": "testrpHS256",
+      "owner": null,
+      "client_type": "confidential",
+      "client_id": "1",
+      "client_secret": "bd01adf93cfb",
+      "jwt_alg": "HS256",
+      "date_created": "2017-11-10",
+      "website_url": "",
+      "terms_url": "",
+      "contact_email": "",
+      "logo": "",
+      "reuse_consent": true,
+      "require_consent": true,
+      "_redirect_uris": "http://testrp:8081/oidc/callback/",
+      "_post_logout_redirect_uris": "",
+      "_scope": "",
+      "response_types": [
+        1
+      ]
+    }
+  },
+  {
+    "model": "oidc_provider.client",
+    "pk": 2,
+    "fields": {
+      "name": "testrpRS256",
+      "owner": null,
+      "client_type": "confidential",
+      "client_id": "2",
+      "client_secret": "a6b4dad2f215",
+      "jwt_alg": "RS256",
+      "date_created": "2017-11-10",
+      "website_url": "",
+      "terms_url": "",
+      "contact_email": "",
+      "logo": "",
+      "reuse_consent": true,
+      "require_consent": true,
+      "_redirect_uris": "http://testrp:8081/oidc/callback/",
+      "_post_logout_redirect_uris": "",
+      "_scope": "",
+      "response_types": [
+        1
+      ]
+    }
+  },
+  {
+    "model": "oidc_provider.rsakey",
+    "pk": 3,
+    "fields": {
+      "key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDAAgiIdiJG7GSMKTRbnGjWpHp1ulJ43/iQjDywWh5MP3in2PK8\nPVI6ItxIFLV81nWZMymA7hjfP7adOlxKY6rI+fExn8cTimI3W/oX6mHrPXm52uj/\nwe839pxxkeD7cmWgaif9Sujuy5AHUuUM1BTlO55POHkmhWyYMKC2P29qgQIDAQAB\nAoGAUHdJri6b1M8yoA6Qk6frw7AwZfAMqf1qxOEQefN6aQfcf7MKntqwAA8l88tB\n96xEokxvo0mlAMJJvIB9tusn4dIHKpmQGacQWVd/KONxPkvyuGgQXX5KCusZTbg7\ni6YQM52RGbExVFWLdGYJRBvzyfRkWX0b4LiderPZUiD6J/UCQQDZIgnLqYyGw3Ro\nnNboWYyOtLhKMF59f/0aSMXLlWdsnFG8kVm/7tw6jcDBalELci/+ExL2JACGwDea\n8DpvWiEDAkEA4mCovWmMDiS8tQCeY5NDic1wMp51+Ya8RX47bvb5F+X7SSE9L87y\n6eU9zVBSY8F+9npkvrxoU9PlKbS3Lzz1KwJAZ5/8BsuS+lnbe3Wmhtr93rlW3mk5\nHzHu7BVg+GkEI+xygcjoiVYImpU+MdB4fzrutpYJzZie+7BOmU4exTfBWwJBAKj+\nN3mO/Xrhee41VAhJuzV4I7XmDXQFXS8TmRKxVCq/COQC6EZ0W2q4M3a964OEw18E\n54hr5gYOPRjxS378JpkCQDjKw2Vyw0S0M8O2hOGuNsUtlGApYKt2iA41jGUf7bvO\nWz/tQuEIXQMd4e9zxNxOzPJOtjR1gyPZyi/FvsgDJDU=\n-----END RSA PRIVATE KEY-----"
+    }
+  }
+]

--- a/testprovider/fixtures.json
+++ b/testprovider/fixtures.json
@@ -1,5 +1,13 @@
 [
   {
+    "model": "sites.site",
+    "pk": 1,
+    "fields": {
+      "domain": "testprovider:8080",
+      "name": "testprovider"
+    }
+  },
+  {
     "model": "oidc_provider.responsetype",
     "pk": 1,
     "fields": {

--- a/testprovider/oidcprovider/templates/home.html
+++ b/testprovider/oidcprovider/templates/home.html
@@ -1,14 +1,14 @@
-<html>
-  <body>
-    <div>
-      Welcome to testprovider!
-    </div>
-    <div>
-      {% if request.user.is_authenticated %}
-        <p>Current user: {{ user.email }}</p>
-      {% else %}
-        <p>User not logged in</p>
-      {% endif %}
-    </div>
-  </body>
-</html>
+{% extends "site_base.html" %}
+
+{% block head_title %}Home{% endblock %}
+
+{% block body %}
+<h1>Welcome to {% if SITE_NAME %}{{ SITE_NAME }}{% else %}testprovider{% endif %}!</h1>
+<div>
+  {% if request.user.is_authenticated %}
+    <p>Current user: {{ user.email }}</p>
+  {% else %}
+    <p>User not logged in</p>
+  {% endif %}
+</div>
+{% endblock body %}

--- a/testprovider/oidcprovider/templates/site_base.html
+++ b/testprovider/oidcprovider/templates/site_base.html
@@ -1,18 +1,28 @@
 {% extends "theme_bootstrap/base.html" %}
-{% block nav %}
-  <ul class="nav navbar-nav navbar-left">
-    <li><a href="#">Link 1</a>
-      <li><a href="#">Link 2</a>
-  </ul>
+{% load staticfiles %}
 
+{% block footer %}
+    <p>Test OIDC provider</p>
 {% endblock %}
-{%  block footer %}
 
-  <div class="container">
-    <hr>
-    <footer>
-      <p>Test OIDC provider</p>
-    </footer>
-  </div>
+{% block styles %}
+  <link rel="stylesheet" href="{% static 'pinax/css/theme.css' %}">
+  <link rel="stylesheet"
+        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+        crossorigin="anonymous">
+  <link rel="stylesheet"
+        href="https://stackpath.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css"
+        integrity="sha384-MI32KR77SgI9QAPUs+6R7leEOwtop70UsjEtFEezfKnMjXWx15NENsZpfDgq8m8S"
+        crossorigin="anonymous">
+{% endblock styles %}
 
-{% endblock %}
+{% block scripts %}
+  <script src="https://code.jquery.com/jquery-2.2.4.min.js"
+          integrity="sha384-rY/jv8mMhqDabXSo+UCggqKtdmBfd3qC2/KvyTDNQ6PcUJXaxK1tMepoQda4g5vB"
+          crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+          integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+          crossorigin="anonymous"></script>
+{% endblock scripts %}
+


### PR DESCRIPTION
Load the pinax-bootstrap-theme assets from CDNs, with integrity hashes:
* Bootstrap 3.3.7
* Font Awesome 4.4.0
* jQuery 2.2.4

This required setting the Site object, which defaults to example.com, and reformatting the templates to work with bootstrap. This PR fixes issue #3.

Here's what testprovider currently looks like:

<img width="903" alt="moz-django-oidc current" src="https://user-images.githubusercontent.com/286017/57410586-cd0ee900-71b0-11e9-8dae-c5113b8889f1.png">

And here is what it looks like after this change:

<img width="903" alt="moz-django-oidc with bootstrap" src="https://user-images.githubusercontent.com/286017/57410599-d7c97e00-71b0-11e9-9c94-1ef495192561.png">

