### PR TITLE
Fix CircleCI to push all images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,26 @@ jobs:
               set -e
             }
 
-            # push to dockerhub on git tag
-            if [ -n "${CIRCLE_TAG}" ]; then
-              echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USERNAME}" --password-stdin
-              retry docker tag "oidc_testprovider:latest" "mozilla/oidc_testprovider:${CIRCLE_TAG}"
-              retry docker push "mozilla/oidc_testprovider:${CIRCLE_TAG}"
-            fi
+            export NAMESPACE=mozilla
+            export IMAGES=(oidc_e2e_setup_py2 oidc_e2e_setup_py3 oidc_testprovider oidc_testrp_py2 oidc_testrp_py3 oidc_testrunner)
 
+            # If a tag was pushed to github, push tagged images and latest
+            # images to Dockerhub
+            if [ -n "${CIRCLE_TAG}" ]; then
+              # Log into Dockerhub
+              echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USERNAME}" --password-stdin
+
+              for IMAGE in $IMAGES
+              do
+                # Tag and push tagged image.
+                retry docker tag "${IMAGE}:latest" "${NAMESPACE}/${IMAGE}:${CIRCLE_TAG}"
+                retry docker push "${NAMESPACE}/${IMAGE}:${CIRCLE_TAG}"
+
+                # Tag and push latest image.
+                retry docker tag "${IMAGE}:latest" "${NAMESPACE}/${IMAGE}:latest"
+                retry docker push "${NAMESPACE}/${IMAGE}:latest"
+              done
+            fi
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
 DEFAULT_GOAL := help
 
-NS ?= mozillaparsys
+NS ?= mozilla
 IMAGES := oidc_testprovider oidc_testrunner oidc_testrp_py2 oidc_testrp_py3 oidc_e2e_setup_py2 oidc_e2e_setup_py3
 BUILD := $(addprefix build-,${IMAGES})
-PUSH := $(addprefix push-,$(IMAGES))
 PULL := $(addprefix pull-,$(IMAGES))
-TAG := $(addprefix tag-,$(IMAGES))
 CLEAN := $(addprefix clean-,$(IMAGES))
-RELEASE := $(addprefix release-,$(IMAGES))
 
 .PHONY: help
 help:
@@ -16,32 +13,15 @@ help:
 .PHONY: build
 build: ${BUILD} ## Build all images
 
-.PHONY: tag
-tag: ${TAG} ## Tag all images
-
-.PHONY: push
-push: ${PUSH} ## Push all images
-
 .PHONY: pull
 pull: ${PULL} ## Pull all images
 
-.PHONY: release
-release: ${BUILD} ${TAG} ${PUSH} ## Release new images (build/tag/push)
-
 .PHONY: clean
-clean: ${CLEAN}
+clean: ${CLEAN} ## Clean images and other artifacts
 
 .PHONY: ${BUILD}
 ${BUILD}: build-%:
 	docker build -t $(subst _py,:py,$(*)) -f dockerfiles/$* .
-
-.PHONY: ${TAG}
-${TAG}: tag-%:
-	docker tag $(subst _py,:py,$(*)) ${NS}/$(subst _py,:py,$(*))
-
-.PHONY: ${PUSH}
-${PUSH}: push-%:
-	docker push ${NS}/$(subst _py,:py,$(*))
 
 .PHONY: ${PULL}
 ${PULL}: pull-%:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Docker images
 ---------------
 
 * `testprovider`
-    * Provides a docker setup for an OIDC OP with preconfigured OIDC client IDs and secrets
+    * Provides a docker image for an OIDC OP with preconfigured OIDC client IDs and secrets
     * OIDC provider endpoint is exposed in port `8080`
     * Provides a Django management command for creating users
     * Uses `django-oidc-provider`
+    * https://hub.docker.com/r/mozilla/oidc_testprovider
 * `testrp-py{2,3}`
     * Test django project preconfigured to work with `testprovider`
     * Uses `mozilla-django-oidc` as an authentication backend
@@ -26,13 +27,25 @@ Build
 ------
 
 We use `make` to automate the docker image workflow.
-For more info run `make help`
+
+For more info run `make help`.
 
 Usage
 ------
 
 In order for this setup to work `testprovider`, `testrp` hostnames should resolve to the
 IP of the docker image (for local development it's `127.0.0.1`).
+
+You can add the resolution to your `/etc/hosts` file.
+
+You can also use [nip.io](http://nip.io/). For example, if you name the service
+"oidcprovider", then you could have these three variables:
+
+```
+OIDC_OP_AUTHORIZATION_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/authorize
+OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/token
+OIDC_OP_USER_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/userinfo
+```
 
 Example setup
 ---------------


### PR DESCRIPTION
This fixes the CircleCI code to push all the images.

Previously, there were only `latest` images. It's better to have git tags that correspond to specific images. Then users don't have images change without their intervention and if we ever goof, someone can downgrade to a previously working image.

This removes the tag, push, and release rules from the Makefile since tagging, pushing, and releasing will all be done by CircleCI going forward.

I also adjusted the README to have the dockerhub url for `oidc_testprovider`.

I also added a note about nip.io. We use that in Socorro. It made some things easier and reduced startup steps.