### PR TITLE
Restrict django in testprovider to 2.2.12

### DIFF
--- a/testprovider/requirements.txt
+++ b/testprovider/requirements.txt
@@ -1,4 +1,4 @@
-django<3
+django==2.2.12
 django-oidc-provider
 django-user-accounts
 pinax-theme-bootstrap


### PR DESCRIPTION
This changes pinning django to a specific version. I'm hoping it alleviates GitHub security vulnerability notices.