### PR TITLE
Update docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ jobs:
           name: Get info
           command: uname -v
 
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
 
       - run:
           name: Get info 


### PR DESCRIPTION
This explicitly sets the Docker version. If we don't set the version,
CircleCI defaults to using 17.03.0 which is a version that CircleCI is
deprecating.