### PR TITLE
stop using ci-docker-bases (#29)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 # Python CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
@@ -18,7 +19,7 @@ jobs:
           version: 19.03.13
 
       - run:
-          name: Get info 
+          name: Get info
           command: docker info
 
       - run:
@@ -37,6 +38,7 @@ jobs:
       - run:
           name: Push to Dockerhub on tag
           working_directory: /oidc_testprovider
+          # yamllint disable rule:line-length
           command: |
             function retry {
               set +e
@@ -81,6 +83,7 @@ jobs:
                 retry docker push "${DOCKER_NAMESPACE}:${IMAGE}-latest"
               done
             fi
+          # yamllint enable rule:line-length
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,37 +7,32 @@ version: 2
 jobs:
   build:
     docker:
-      - image: mozilla/cidockerbases:docker-latest
-    working_directory: /
+      - image: cimg/python:3.10.2
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
 
     steps:
+      - checkout
+
       - run:
           name: Get info
           command: uname -v
 
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.11
 
       - run:
           name: Get info
           command: docker info
 
       - run:
-          name: Install essential packages
-          command: apt-get install make
-
-      - checkout:
-          path: /oidc_testprovider
-
-      - run:
           name: Build Docker images
-          working_directory: /oidc_testprovider
           command: |
             make build
 
       - run:
           name: Push to Dockerhub on tag
-          working_directory: /oidc_testprovider
           # yamllint disable rule:line-length
           command: |
             function retry {
@@ -61,7 +56,7 @@ jobs:
             # Namespace on dockerhub to push:
             # https://hub.docker.com/u/mozilla/oidc-testprovider
             export DOCKER_NAMESPACE=mozilla/oidc-testprovider
-            export IMAGES=(oidc_e2e_setup_py2 oidc_e2e_setup_py3 oidc_testprovider oidc_testrp_py2 oidc_testrp_py3 oidc_testrunner)
+            export IMAGES=(oidc_e2e_setup_py3 oidc_testprovider oidc_testrp_py3 oidc_testrunner)
 
             # If a tag was pushed to github, push tagged images and latest
             # images to Dockerhub

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://hub.docker.com/r/mozilla/oidc-testprovider/tags?name=testprovider
 * OIDC provider endpoint is exposed in port `8080`
 * Provides a Django management command for creating users
 * Uses `django-oidc-provider`
+* Great for local development environments!
 
 
 ### Usage


### PR DESCRIPTION
This switches us from ci-docker-bases image which is no longer maintained to cimg/python image which is. It also removes building two images we no longer maintain and cleans up the config.yml file a little.

Fixes #29.