### PR TITLE
Use exec to run the server in run.sh.

### DIFF
--- a/testprovider/bin/run.sh
+++ b/testprovider/bin/run.sh
@@ -2,4 +2,4 @@
 
 python manage.py migrate --noinput
 python manage.py loaddata fixtures.json
-python manage.py runserver 0.0.0.0:8080
+exec python manage.py runserver 0.0.0.0:8080


### PR DESCRIPTION
By running the server with exec, the shell will be replaced by the Python interpreter. This ensures the container is properly reacting to signals from Docker, since they will now go to the Python interpreter running the server rather than to the shell script.