### PR TITLE
Update remote docker version in CircleCI config (#85)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: uname -v
 
       - setup_remote_docker:
-          version: 20.10.11
+          version: default
 
       - run:
           name: Get info


### PR DESCRIPTION
We were using a version no longer supported. This changes the specified version to default which should be fine and means we don't have to do this again.

Fixes #85