### PR TITLE
Update Python versions to latest patch in Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ OIDC_OP_USER_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/userinfo
 version: '3'
 services:
   testprovider:
-    image: mozilla/oidc-testprovider:oidc_testprovider-v0.9.3
+    image: mozilla/oidc-testprovider:oidc_testprovider-v0.10.9
     ports:
       - "8080:8080"
 ```
@@ -92,7 +92,7 @@ All images are pushed to: https://hub.docker.com/r/mozilla/oidc-testprovider
 version: '3'
 services:
   testrp:
-    image: mozilla/oidc-testprovider:oidc_testrp_py3-v0.9.3
+    image: mozilla/oidc-testprovider:oidc_testrp_py3-v0.10.9
     ports:
       - "8081:8081"
     environment:

--- a/dockerfiles/oidc_e2e_setup_py310
+++ b/dockerfiles/oidc_e2e_setup_py310
@@ -1,4 +1,4 @@
-FROM python:3.10.13-bookworm
+FROM python:3.10.15-bookworm
 
 EXPOSE 8080 8081
 

--- a/dockerfiles/oidc_e2e_setup_py311
+++ b/dockerfiles/oidc_e2e_setup_py311
@@ -1,4 +1,4 @@
-FROM python:3.11.8-bookworm
+FROM python:3.11.10-bookworm
 
 EXPOSE 8080 8081
 

--- a/dockerfiles/oidc_e2e_setup_py312
+++ b/dockerfiles/oidc_e2e_setup_py312
@@ -1,4 +1,4 @@
-FROM python:3.12.2-bookworm
+FROM python:3.12.7-bookworm
 
 EXPOSE 8080 8081
 

--- a/dockerfiles/oidc_e2e_setup_py39
+++ b/dockerfiles/oidc_e2e_setup_py39
@@ -1,4 +1,4 @@
-FROM python:3.9.18-bookworm
+FROM python:3.9.20-bookworm
 
 EXPOSE 8080 8081
 

--- a/dockerfiles/oidc_testprovider
+++ b/dockerfiles/oidc_testprovider
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11.10-bookworm
 EXPOSE 8080
 COPY testprovider /code/
 WORKDIR /code


### PR DESCRIPTION
This updates oidc_e2e_* files to latest Python patch versions.

This updates oidc_testprovider to Python 3.11.10. It uses django-oidc-provider which doesn't explicitly support Python past 3.11 at this time.